### PR TITLE
[Fix] Change the margin on the sidebar icons to not create unexpected margin

### DIFF
--- a/app/views/shared/_sidebar.html.erb
+++ b/app/views/shared/_sidebar.html.erb
@@ -21,25 +21,25 @@
       <li class="flex justify-start">
         <%= link_to my_projects_path, class: "px-4 py-2 block hover:bg-saddle-taupe hover-btn-pixel #{'bg-saddle-taupe btn-pixel' if current_page?(my_projects_path) || (controller_name == 'projects' && action_name == 'show' && @project&.user == current_user)}" do %>
           <%= inline_svg "radio-tower.svg", class: "2xl:h-12 2xl:w-12 inline h-10 w-10", data: { 'sidebar-target': 'icon' } %>
-          <span data-sidebar-target="content" class="ml-2>My Project</span>
+          <span data-sidebar-target="content" class="ml-2">My Project</span>
         <% end %>
       </li>
       <li class="flex justify-start">
         <%= link_to stonks_path, class: "px-4 py-2 block hover:bg-saddle-taupe hover-btn-pixel #{'bg-saddle-taupe btn-pixel' if current_page?(stonks_path)}" do %>
           <%= inline_svg "dollar.svg", class: "2xl:h-12 2xl:w-12 inline h-10 w-10", data: { 'sidebar-target': 'icon' } %>
-          <span data-sidebar-target="content" class="ml-2>Stonks</span>
+          <span data-sidebar-target="content" class="ml-2">Stonks</span>
         <% end %>
       </li>
       <li class="flex justify-start">
         <%= link_to activity_path, class: "px-4 py-2 block hover:bg-saddle-taupe hover-btn-pixel #{'bg-saddle-taupe btn-pixel' if current_page?(activity_path)}" do %>
           <%= inline_svg "notification.svg", class: "2xl:h-12 2xl:w-12 inline h-10 w-10", data: { 'sidebar-target': 'icon' } %>
-          <span data-sidebar-target="content" class="ml-2>Activity</span>
+          <span data-sidebar-target="content" class="ml-2">Activity</span>
         <% end %>
       </li>
       <li class="flex justify-start">
         <%= link_to new_vote_path, class: "px-4 py-2 block hover:bg-saddle-taupe hover-btn-pixel #{'bg-saddle-taupe btn-pixel' if current_page?(new_vote_path)}" do %>
           <%= inline_svg "trophy.svg", class: "2xl:h-12 2xl:w-12 inline h-10 w-10", data: { 'sidebar-target': 'icon' } %>
-          <span data-sidebar-target="content" class="ml-2>Vote</span>
+          <span data-sidebar-target="content" class="ml-2">Vote</span>
         <% end %>
       </li>
     </ul>


### PR DESCRIPTION
## Example:
Before:
![image](https://github.com/user-attachments/assets/049c8bb9-baed-4d95-8214-604321dfdcf3)

Now:
![image](https://github.com/user-attachments/assets/52735484-c909-4c98-b319-9ad19f41a0d4)
